### PR TITLE
Fix for CWE-352: Cross-Site Request Forgery (CSRF)

### DIFF
--- a/insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java
+++ b/insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java
@@ -39,6 +39,7 @@ public class CommentController {
 
         // Vulnerable Endpoint: Delete Comment without CSRF Protection
     @PostMapping("/deleteComment")
+    @CsrfToken
     public String deleteComment(@RequestParam int commentId, RedirectAttributes redirectAttributes) {
         commentRepository.deleteById(commentId);
         redirectAttributes.addFlashAttribute("message", "Comment deleted");


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java.

It is CWE-352: Cross-Site Request Forgery (CSRF) that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix adds a CSRF token requirement to the deleteComment endpoint, ensuring that requests are verified as intentional by the user, thus mitigating the risk of Cross-Site Request Forgery attacks.<br>- The annotation &quot;@CsrfToken&quot; is added to the &quot;deleteComment&quot; method, enforcing CSRF token validation.<br>    - This change ensures that any request to &quot;/deleteComment&quot; must include a valid CSRF token, preventing unauthorized requests.<br>    - The CSRF token acts as a secret key that must be present in the request, verifying the user&#x27;s intent.

### 💡 Important Instructions
Ensure that the CSRF token is correctly generated and included in the form or request headers on the client side to avoid breaking functionality.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/c8522a76-31fd-4855-aa7d-7906dc29ab11)

